### PR TITLE
Add ability to configure the maxBuffer

### DIFF
--- a/tasks/lib/phpcs.js
+++ b/tasks/lib/phpcs.js
@@ -24,7 +24,8 @@ exports.init = function(grunt) {
             standard: false,
             verbose: false,
             reportFile: false,
-            report: 'full'
+            report: 'full',
+            maxBuffer: 200*1024
         },
         cmd    = null,
         done   = null,
@@ -103,8 +104,11 @@ exports.init = function(grunt) {
      *
      */
     exports.run = function() {
+        var cmdOptions = {
+            maxBuffer: config.maxBuffer
+        };
 
-        exec(cmd, function(err, stdout, stderr) {
+        exec(cmd, cmdOptions, function(err, stdout, stderr) {
 
             if (stdout) {
                 grunt.log.write(stdout);


### PR DESCRIPTION
The maxBuffer defaults to 200*1024, which might be too short if you
expect a lot of errors during development or if you import new
codebases. Now you can override it.
