### PR TITLE
Add ability to ignore the status code of phpcs

### DIFF
--- a/tasks/lib/phpcs.js
+++ b/tasks/lib/phpcs.js
@@ -24,7 +24,8 @@ exports.init = function(grunt) {
             standard: false,
             verbose: false,
             reportFile: false,
-            report: 'full'
+            report: 'full',
+            ignoreExitCode: false
         },
         cmd    = null,
         done   = null,
@@ -111,7 +112,9 @@ exports.init = function(grunt) {
             }
 
             if (err) {
-                grunt.fatal(err);
+                if (! config.ignoreExitCode) {
+                    grunt.fatal(err);
+                }
             }
             done();
         });


### PR DESCRIPTION
When I use phpcs in an CI-environment, I do not necessary want to fail
the run just because of errors, as long as a report is written that my
CI-Server can use.
