### PR TITLE
Add the "-s" switch as an option. 

### DIFF
--- a/tasks/lib/phpcs.js
+++ b/tasks/lib/phpcs.js
@@ -95,6 +95,10 @@ exports.init = function(grunt) {
             // Output more verbose information.
             cmd += ' -v';
         }
+        if (config.showSniffCodes === true) {
+            // Show sniff codes in all reports
+            cmd += ' -s';
+        }
         return cmd;
     };
 


### PR DESCRIPTION
Another very useful option of phpcs is the -s switch.
This allows to print the rule name (sniff code) on all reports.

For example:

<pre>
--------------------------------------------------------------------------------
FOUND 1 ERROR(S) AFFECTING 1 LINE(S)
--------------------------------------------------------------------------------
 1 | ERROR | The PHP open tag does not have a corresponding PHP close tag
   |       | (Generic.PHP.ClosingPHPTag.NotFound)
--------------------------------------------------------------------------------
</pre>


With the -s switch, we can easily know that the actual rule that threw the error is "Generic.PHP.ClosingPHPTag.NotFound"
