### PR TITLE
Fix usage example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ _This task is a [multi task][] so any targets, files and options should be speci
 ```js
 phpcs: {
 	application: {
-		dir: ['application/classes/*.php', application/lib/**/*.php]
+		dir: ['application/classes/*.php', 'application/lib/**/*.php']
 	},
 	options: {
 		bin: 'vendor/bin/phpcs',


### PR DESCRIPTION
A string was not enclosed in quotes in the JS code of usage example.
