### PR TITLE
Convert 'dir' setting to 'src

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ function log(err, stdout, stderr, cb) {
 grunt.initConfig({
 	phpcs: {
 		application: {
-    		dir: ['application/classes/*.php', 'application/lib/**/*.php']
+    		src: ['application/classes/*.php', 'application/lib/**/*.php']
         },
         options: {
             callback: log

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
       "email": "chat@jamescryer.com",
       "url": "http://www.jamescryer.com/"
   }],
-  "version": "0.2.2",
+  "version": "0.2.3",
   "main": "Gruntfile.js",
   "engines": {
     "node": "0.10.x"


### PR DESCRIPTION
I converted the 'dir' setting to 'src' so that it can be used with the grunt-newer module (https://github.com/tschaub/grunt-newer)