### PR TITLE
Remove reportFile parameter if false to allow explicit stdout config.

### DIFF
--- a/tasks/phpcs.js
+++ b/tasks/phpcs.js
@@ -47,7 +47,10 @@ module.exports = function(grunt) {
         files = files.filter(function(file, position) { 
             return !position || file !== files[position - 1];
         });
-        
+
+        // If --report-file is false PHPCS does not output anything.
+        if (!options.reportFile) delete options.reportFile;
+
         // generates parameters
         parameters = Object.keys(options).map(function(option) {
             return option in command.flags && options[option] === true ? 


### PR DESCRIPTION
If overriding the reportFile property from specified to `false`, it will pass thru --report-file=false to phpcs. This suppresses that behavior to get stdout as expected.
