### PR TITLE
List files via standard grunt processing for newer compatibility

### DIFF
--- a/tasks/phpcs.js
+++ b/tasks/phpcs.js
@@ -41,7 +41,7 @@ module.exports = function(grunt) {
             target = this.target,
             options = this.options(defaults),
             execute = path.normalize(options.bin),
-            files = [].concat.apply([], this.files.map(function(mapping) { return mapping.src; })).sort();
+            files = this.filesSrc.sort();
         
         // removes duplicate files
         files = files.filter(function(file, position) { 


### PR DESCRIPTION
After some time researching the issue (by way of #23) I learned that grunt's core handling of files configuration already produces a flattened list of all files for task processing. The grunt-newer plugin takes advantage of that behavior to then strip down that list of files to only those that meet it's criteria to move forward.

This change aligns grunt-phpcs with this pipeline and allows grunt-newer to work.
